### PR TITLE
✨feat: upgrade JS SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "featureprobe-client-sdk-react",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "featureprobe-client-sdk-react",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "featureprobe-client-sdk-js": "^2.0.2"
+        "featureprobe-client-sdk-js": "^2.0.3"
       },
       "devDependencies": {
         "@commitlint/cli": "^13.1.0",
@@ -5193,9 +5193,9 @@
       }
     },
     "node_modules/featureprobe-client-sdk-js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/featureprobe-client-sdk-js/-/featureprobe-client-sdk-js-2.0.2.tgz",
-      "integrity": "sha512-1/tafUl0XpSU+x6blWGMK/qqcyJYD0AhgQQOslcM+qkhyc1gY1pKqvtVGZQPD91RxqLkBjSiWyk64QFm0ZP2ng==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/featureprobe-client-sdk-js/-/featureprobe-client-sdk-js-2.0.3.tgz",
+      "integrity": "sha512-GG1El4PMTDSO0+Ys/8plah+yxjWzLA5hbSbTh6FhXxxkVYy+MRHpA2fu3xL1szVxoPQoZMSwUkXi9rp9tOjdqg==",
       "dependencies": {
         "js-base64": "^3.7.2",
         "socket.io-client": "^4.5.4",
@@ -15553,9 +15553,9 @@
       }
     },
     "featureprobe-client-sdk-js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/featureprobe-client-sdk-js/-/featureprobe-client-sdk-js-2.0.2.tgz",
-      "integrity": "sha512-1/tafUl0XpSU+x6blWGMK/qqcyJYD0AhgQQOslcM+qkhyc1gY1pKqvtVGZQPD91RxqLkBjSiWyk64QFm0ZP2ng==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/featureprobe-client-sdk-js/-/featureprobe-client-sdk-js-2.0.3.tgz",
+      "integrity": "sha512-GG1El4PMTDSO0+Ys/8plah+yxjWzLA5hbSbTh6FhXxxkVYy+MRHpA2fu3xL1szVxoPQoZMSwUkXi9rp9tOjdqg==",
       "requires": {
         "js-base64": "^3.7.2",
         "socket.io-client": "^4.5.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "featureprobe-client-sdk-react",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "FeatureProbe Client Side SDK for React",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -43,7 +43,7 @@
     "url": "https://github.com/FeatureProbe/client-sdk-react/issues"
   },
   "dependencies": {
-    "featureprobe-client-sdk-js": "^2.0.2"
+    "featureprobe-client-sdk-js": "^2.0.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",


### PR DESCRIPTION
- Upgrade JS SDK to `2.0.3`. In this version, `track` api does not need to pass in `user` as a required parameter